### PR TITLE
Fix namespace for Validator Interface in Api Manager

### DIFF
--- a/ApiManager.php
+++ b/ApiManager.php
@@ -29,7 +29,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ApiManager
 {


### PR DESCRIPTION
The namespace changed in newer Symfony version. Please merge into 2.0.