### PR TITLE
 Resolve request locale from the accept-language header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 4.2.0
+### Added
+- New optional bundle configuration parameter `locales`
+
+### Changed
+- `\Symfony\Component\HttpFoundation\Request::getLocale` now can return preferred locale from the `Accept-Language` header, which resolves from the `locales` parameter in the bundle configuration
+
 ## 4.1.1
 ### Added
 - Moved `Paysera\Bundle\RestBundle\Listener\RestListener::onKernelException` logging to service `Paysera\Bundle\RestBundle\Service\ExceptionLogger`

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,7 +22,12 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-            ->scalarNode('property_path_converter')->defaultNull()->end()
+                ->scalarNode('property_path_converter')
+                    ->defaultNull()
+                ->end()
+                ->arrayNode('locales')
+                    ->prototype('scalar')
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,7 +26,8 @@ class Configuration implements ConfigurationInterface
                     ->defaultNull()
                 ->end()
                 ->arrayNode('locales')
-                    ->prototype('scalar')
+                    ->prototype('scalar')->end()
+                    ->defaultValue([])
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/PayseraRestExtension.php
+++ b/DependencyInjection/PayseraRestExtension.php
@@ -39,5 +39,7 @@ class PayseraRestExtension extends Extension
                 ]
             );
         }
+
+        $container->setParameter('paysera_rest.locales', $config['locales']);
     }
 }

--- a/Listener/RestListener.php
+++ b/Listener/RestListener.php
@@ -36,13 +36,16 @@ class RestListener
      */
     private $loggersCache;
 
+    private $locales;
+
     public function __construct(
         ApiManager $apiManager,
         ContextAwareNormalizerFactory $normalizerFactory,
         LoggerInterface $logger,
         ParameterToEntityMapBuilder $parameterToEntityMapBuilder,
         RequestLogger $requestLogger,
-        ExceptionLogger $exceptionLogger
+        ExceptionLogger $exceptionLogger,
+        array $locales
     ) {
         $this->apiManager = $apiManager;
         $this->normalizerFactory = $normalizerFactory;
@@ -50,6 +53,7 @@ class RestListener
         $this->parameterToEntityMapBuilder = $parameterToEntityMapBuilder;
         $this->requestLogger = $requestLogger;
         $this->exceptionLogger = $exceptionLogger;
+        $this->locales = $locales;
 
         $this->loggersCache = array();
     }
@@ -63,7 +67,12 @@ class RestListener
 
             if ($locale !== null) {
                 $request->setLocale($locale);
+            } else {
+                $request->setLocale(
+                    $request->getPreferredLanguage($this->locales)
+                );
             }
+
             $request->query->remove('locale');
         }
     }
@@ -334,9 +343,9 @@ class RestListener
 
     /**
      * Throws given InvalidDataException as ApiException
-     * 
+     *
      * @param InvalidDataException $exception
-     * 
+     *
      * @throws ApiException
      */
     protected function handleException(InvalidDataException $exception)

--- a/Listener/RestListener.php
+++ b/Listener/RestListener.php
@@ -162,7 +162,7 @@ class RestListener
         if ($cacheStrategy !== null && $cacheStrategy instanceof ResponseAwareCacheStrategy) {
             $cacheStrategy->setResponse($response);
         } else {
-            $response->setPrivate();
+            $response->headers->set('Cache-control', 'no-store, no-cache, must-revalidate');
         }
 
         if ($result !== null) {

--- a/Listener/RestListener.php
+++ b/Listener/RestListener.php
@@ -162,7 +162,10 @@ class RestListener
         if ($cacheStrategy !== null && $cacheStrategy instanceof ResponseAwareCacheStrategy) {
             $cacheStrategy->setResponse($response);
         } else {
-            $response->headers->set('Cache-control', 'no-store, no-cache, must-revalidate');
+            $responseHeaders = $response->headers;
+
+            $responseHeaders->removeCacheControlDirective('public');
+            $responseHeaders->addCacheControlDirective('no-store, no-cache, must-revalidate, private');
         }
 
         if ($result !== null) {

--- a/Listener/RestListener.php
+++ b/Listener/RestListener.php
@@ -68,9 +68,11 @@ class RestListener
             if ($locale !== null) {
                 $request->setLocale($locale);
             } else {
-                $request->setLocale(
-                    $request->getPreferredLanguage($this->locales)
-                );
+                $preferredLanguage = $request->getPreferredLanguage($this->locales);
+
+                if ($preferredLanguage !== null) {
+                    $request->setLocale($preferredLanguage);
+                }
             }
 
             $request->query->remove('locale');

--- a/Listener/RestListener.php
+++ b/Listener/RestListener.php
@@ -70,7 +70,11 @@ class RestListener
             } else {
                 $preferredLanguage = $request->getPreferredLanguage($this->locales);
 
-                if ($preferredLanguage !== null) {
+                if (
+                    $preferredLanguage !== null
+                    && count($this->locales) > 0
+                    && in_array($preferredLanguage, $request->getLanguages(), true)
+                ) {
                     $request->setLocale($preferredLanguage);
                 }
             }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ class AppKernel extends Kernel
 }
 ```
 
+Configuration
+-----------
+- Example of the full bundle configuration
+
+```yaml
+paysera_rest:
+    property_path_converter: 'my_custom_path_converter' # Overrides the default path converter
+    locales: ['en', 'ru', 'lt'] # Optional list of accepted locales
+```
+
 Basic Usage
 -----------
 - Create and configure your controller:

--- a/Resources/config/services/services.xml
+++ b/Resources/config/services/services.xml
@@ -87,6 +87,7 @@
             <argument type="service" id="paysera_rest.service.parameter_to_entity_map_builder"/>
             <argument type="service" id="paysera_rest.service.request_logger"/>
             <argument type="service" id="paysera_rest.service.exception_logger"/>
+            <argument>%paysera_rest.locales%</argument>
         </service>
 
         <!-- Encoding -->

--- a/Tests/Listener/RestListenerLocaleTest.php
+++ b/Tests/Listener/RestListenerLocaleTest.php
@@ -57,24 +57,29 @@ class RestListenerLocaleTest extends PHPUnit_Framework_TestCase
     public function dataProviderForTestLocaleIsBeingSet()
     {
         return [
-            'select requested locale' => [
+            'select requested locale from the provided configuration' => [
                 ['lt', 'ru'],
                 'lt',
-                'lt'
+                'lt',
             ],
-            'select locale with the highest weight' => [
+            'if no configuration is provided, don\'t change the locale' => [
                 [],
-                'zh',
-                'zh, en-us; q=0.8, en; q=0.6',
+                'en',
+                'fr-CH, fr;q=0.9, lt;q=0.8, de;q=0.7',
             ],
-            'select locale from the defined locale array' => [
+            'select locale from the defined locale configuration despite it having lowest weight' => [
                 ['en'],
                 'en',
                 'zh, en-us; q=0.8, en; q=0.6',
             ],
-            'fallback to the default locale' => [
+            'fallback to the default locale if neither configuration nor accept language header is provided' => [
                 [],
                 'en',
+            ],
+            'fallback to the default locale if requested locale is not configured' => [
+                ['ru', 'zh'],
+                'en',
+                'fr-CH, fr;q=0.9, lt;q=0.8, de;q=0.7',
             ],
         ];
     }

--- a/Tests/Listener/RestListenerLocaleTest.php
+++ b/Tests/Listener/RestListenerLocaleTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Paysera\Bundle\RestBundle\Tests;
+
+use Mockery;
+use Psr\Log\NullLogger;
+use Mockery\MockInterface;
+use PHPUnit_Framework_TestCase;
+use Paysera\Bundle\RestBundle\ApiManager;
+use Symfony\Component\HttpFoundation\Request;
+use Paysera\Bundle\RestBundle\Service\RequestLogger;
+use Paysera\Bundle\RestBundle\Listener\RestListener;
+use Paysera\Bundle\RestBundle\Service\ExceptionLogger;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Paysera\Bundle\RestBundle\Service\ParameterToEntityMapBuilder;
+use Paysera\Component\Serializer\Factory\ContextAwareNormalizerFactory;
+
+class RestListenerLocaleTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MockInterface|GetResponseEvent
+     */
+    private $responseEvent;
+
+    public function setUp()
+    {
+        $this->responseEvent = Mockery::mock(GetResponseEvent::class);
+    }
+
+    /**
+     * @param array $acceptedLocales
+     * @param string $expected
+     * @param string|null $acceptLanguage
+     *
+     * @dataProvider dataProviderForTestLocaleIsBeingSet
+     */
+    public function testCorrectLocaleIsBeingSet(array $acceptedLocales, $expected, $acceptLanguage = null)
+    {
+        $restListener = $this->createRestListener($acceptedLocales);
+
+        $request = new Request();
+
+        if ($acceptLanguage !== null) {
+            $request->headers->set('Accept-Language', $acceptLanguage);
+        }
+
+        $this->responseEvent->shouldReceive('getRequest')->andReturn($request);
+
+        $restListener->onKernelRequest($this->responseEvent);
+
+        $this->assertEquals($expected, $request->getLocale());
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestLocaleIsBeingSet()
+    {
+        return [
+            'select requested locale' => [
+                ['lt', 'ru'],
+                'lt',
+                'lt'
+            ],
+            'select locale with the highest weight' => [
+                [],
+                'zh',
+                'zh, en-us; q=0.8, en; q=0.6',
+            ],
+            'select locale from the defined locale array' => [
+                ['en'],
+                'en',
+                'zh, en-us; q=0.8, en; q=0.6',
+            ],
+            'fallback to the default locale' => [
+                [],
+                'en',
+            ],
+        ];
+    }
+
+    /**
+     * @param array $locales
+     *
+     * @return RestListener
+     */
+    private function createRestListener(array $locales)
+    {
+        $apiManager = Mockery::mock(ApiManager::class);
+        $apiManager->shouldReceive('isRestRequest')->andReturn(true);
+
+        return new RestListener(
+            $apiManager,
+            Mockery::mock(ContextAwareNormalizerFactory::class),
+            new NullLogger(),
+            Mockery::mock(ParameterToEntityMapBuilder::class),
+            new RequestLogger(new NullLogger()),
+            new ExceptionLogger(),
+            $locales
+        );
+    }
+}

--- a/Tests/Listener/RestListenerLocaleTest.php
+++ b/Tests/Listener/RestListenerLocaleTest.php
@@ -68,9 +68,9 @@ class RestListenerLocaleTest extends PHPUnit_Framework_TestCase
                 'fr-CH, fr;q=0.9, lt;q=0.8, de;q=0.7',
             ],
             'select locale from the defined locale configuration despite it having lowest weight' => [
-                ['en'],
-                'en',
-                'zh, en-us; q=0.8, en; q=0.6',
+                ['de'],
+                'de',
+                'fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7',
             ],
             'fallback to the default locale if neither configuration nor accept language header is provided' => [
                 [],

--- a/Tests/Listener/RestListenerPathConverterTest.php
+++ b/Tests/Listener/RestListenerPathConverterTest.php
@@ -22,6 +22,7 @@ use Paysera\Component\Serializer\Factory\ContextAwareNormalizerFactory;
 use Paysera\Component\Serializer\Normalizer\ArrayNormalizer;
 use Paysera\Component\Serializer\Normalizer\ViolationNormalizer;
 use Paysera\Component\Serializer\Validation\PropertyPathConverterInterface;
+use PHPUnit_Framework_TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -31,7 +32,7 @@ use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-class RestListenerPathConverterTest extends \PHPUnit_Framework_TestCase
+class RestListenerPathConverterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var MockInterface|FilterControllerEvent
@@ -45,13 +46,14 @@ class RestListenerPathConverterTest extends \PHPUnit_Framework_TestCase
 
     public function testOnKernelControllerWithRequestQueryMapperValidationThrowsExceptionWithCamelCasePathConverter()
     {
+        $exceptionThrown = false;
         try {
             $this
                 ->createRestListener(new CamelCaseToSnakeCaseConverter())
                 ->onKernelController($this->filterControllerEvent)
             ;
-            $this->setExpectedException(ApiException::class);
         } catch (ApiException $apiException) {
+            $exceptionThrown = true;
             $this->assertEquals(
                 [
                     'first_name' => ['firstName message'],
@@ -68,14 +70,18 @@ class RestListenerPathConverterTest extends \PHPUnit_Framework_TestCase
                 $apiException->getViolations()
             );
         }
+
+        $this->assertTrue($exceptionThrown);
     }
 
     public function testOnKernelControllerWithRequestQueryMapperValidationThrowsExceptionWithNoOpConverter()
     {
+        $exceptionThrown = false;
         try {
             $this->createRestListener(new NoOpConverter())->onKernelController($this->filterControllerEvent);
             $this->setExpectedException(ApiException::class);
         } catch (ApiException $apiException) {
+            $exceptionThrown = true;
             $this->assertEquals(
                 [
                     'firstName' => ['firstName message'],
@@ -92,6 +98,8 @@ class RestListenerPathConverterTest extends \PHPUnit_Framework_TestCase
                 $apiException->getViolations()
             );
         }
+
+        $this->assertTrue($exceptionThrown);
     }
 
     /**

--- a/Tests/Listener/RestListenerTest.php
+++ b/Tests/Listener/RestListenerTest.php
@@ -16,6 +16,7 @@ use Paysera\Component\Serializer\Exception\InvalidDataException;
 use Paysera\Component\Serializer\Factory\ContextAwareNormalizerFactory;
 use Paysera\Component\Serializer\Validation\PropertiesAwareValidator;
 use Paysera\Component\Serializer\Validation\PropertyPathConverterInterface;
+use PHPUnit_Framework_TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,7 +33,7 @@ use Paysera\Component\Serializer\Entity\Violation;
  * These tests use heavy object mocking, however it makes sure that as much code as possible is executed
  * These tests are used for refactoring RestListener
  */
-class RestListenerTest extends \PHPUnit_Framework_TestCase
+class RestListenerTest extends PHPUnit_Framework_TestCase
 {
     /** @var \Mockery\MockInterface|ApiManager */
     private $apiManager;

--- a/Tests/Listener/RestListenerTest.php
+++ b/Tests/Listener/RestListenerTest.php
@@ -2,6 +2,7 @@
 
 namespace Paysera\Bundle\RestBundle\Tests;
 
+use Mockery;
 use Paysera\Bundle\RestBundle\ApiManager;
 use Paysera\Bundle\RestBundle\Exception\ApiException;
 use Paysera\Bundle\RestBundle\Listener\RestListener;
@@ -60,26 +61,26 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->apiManager = \Mockery::mock(ApiManager::class);
+        $this->apiManager = Mockery::mock(ApiManager::class);
 
-        $this->normalizerFactory = \Mockery::mock(ContextAwareNormalizerFactory::class);
+        $this->normalizerFactory = Mockery::mock(ContextAwareNormalizerFactory::class);
 
-        $this->logger = \Mockery::mock(LoggerInterface::class);
+        $this->logger = Mockery::mock(LoggerInterface::class);
         $this->logger->shouldReceive('debug')->andReturnUsing($this->storeLoggerMessage());
 
-        $this->parameterToEntityMapBuilder = \Mockery::mock(ParameterToEntityMapBuilder::class);
+        $this->parameterToEntityMapBuilder = Mockery::mock(ParameterToEntityMapBuilder::class);
 
-        $this->requestLogger = \Mockery::mock(RequestLogger::class);
+        $this->requestLogger = Mockery::mock(RequestLogger::class);
 
-        $this->filterControllerEvent = \Mockery::mock(FilterControllerEvent::class);
+        $this->filterControllerEvent = Mockery::mock(FilterControllerEvent::class);
 
-        $this->exceptionLogger = \Mockery::mock(ExceptionLogger::class);
+        $this->exceptionLogger = Mockery::mock(ExceptionLogger::class);
     }
 
     public function testOnKernelControllerNoMappersOnlyParameterToEntityMap()
     {
         $parameterToEntityMap = ['key' => 'entity'];
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
@@ -106,13 +107,13 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $entity = [1];
         $parameterToEntityMap = ['key' => $entity];
         $name = 'requestName';
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
         $request->attributes = $parameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andReturn($entity);
         $requestMapper->shouldReceive('getName')->andReturn($name);
 
@@ -137,14 +138,14 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
     public function testOnKernelControllerWithRequestMapperWhenDecodingFails()
     {
         $this->setExpectedException(ApiException::class);
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent')->andReturn('a=b&c=d');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
         $request->attributes = $parameterBag;
 
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity');
         $requestMapper->shouldReceive('getName')->andReturn('name');
 
@@ -168,13 +169,13 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(ApiException::class);
         $this->logger->shouldReceive('notice')->andReturnUsing($this->storeLoggerMessage());
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
         $request->attributes = $parameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andThrow(InvalidDataException::class);
         $requestMapper->shouldReceive('getName')->andReturn('name');
 
@@ -198,13 +199,13 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $name = 'requestName';
         $entity = [1];
         $this->logger->shouldReceive('notice')->andReturnUsing($this->storeLoggerMessage());
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
         $request->attributes = $parameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andReturn($entity);
         $requestMapper->shouldReceive('getName')->andReturn($name);
 
@@ -229,13 +230,13 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $name = 'requestName';
         $entity = [1];
         $this->logger->shouldReceive('notice')->andReturnUsing($this->storeLoggerMessage());
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
         $request->attributes = $parameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andReturn($entity);
         $requestMapper->shouldReceive('getName')->andReturn($name);
 
@@ -267,13 +268,13 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $name = 'requestName';
         $entity = [1];
         $this->logger->shouldReceive('notice')->andReturnUsing($this->storeLoggerMessage());
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
         $request->attributes = $parameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andReturn($entity);
         $requestMapper->shouldReceive('getName')->andReturn($name);
 
@@ -302,7 +303,7 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(ApiException::class);
         $this->logger->shouldReceive('notice')->andReturnUsing($this->storeLoggerMessage());
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
@@ -310,7 +311,7 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $queryParameterBag = new ParameterBag();
         $request->query = $queryParameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andThrow(InvalidDataException::class);
         $requestMapper->shouldReceive('getName')->andReturn('name');
 
@@ -335,7 +336,7 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $name = 'requestName';
         $entity = [1];
         $this->logger->shouldReceive('notice')->andReturnUsing($this->storeLoggerMessage());
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
@@ -343,7 +344,7 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $queryParameterBag = new ParameterBag();
         $request->query = $queryParameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andReturn($entity);
         $requestMapper->shouldReceive('getName')->andReturn($name);
 
@@ -373,7 +374,7 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $name = 'requestName';
         $entity = [1];
         $this->logger->shouldReceive('notice')->andReturnUsing($this->storeLoggerMessage());
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
@@ -381,7 +382,7 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $queryParameterBag = new ParameterBag();
         $request->query = $queryParameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andReturn($entity);
         $requestMapper->shouldReceive('getName')->andReturn($name);
 
@@ -415,7 +416,7 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
             'last_name' => 2,
         ];
         $this->logger->shouldReceive('notice')->andReturnUsing($this->storeLoggerMessage());
-        $request = \Mockery::mock(Request::class);
+        $request = Mockery::mock(Request::class);
         $request->shouldReceive('getContent');
         $parameterBag = new ParameterBag();
         $parameterBag->set('_controller', 'controller');
@@ -423,7 +424,7 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $queryParameterBag = new ParameterBag();
         $request->query = $queryParameterBag;
 
-        $requestMapper = \Mockery::mock(NameAwareDenormalizerInterface::class);
+        $requestMapper = Mockery::mock(NameAwareDenormalizerInterface::class);
         $requestMapper->shouldReceive('mapToEntity')->andReturn($entity);
         $requestMapper->shouldReceive('getName')->andReturn($name);
 
@@ -437,16 +438,16 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $this->apiManager->shouldReceive('getValidationGroups')->andReturn([RestApi::DEFAULT_VALIDATION_GROUP]);
 
         if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $validator = \Mockery::mock(ValidatorInterface::class);
+            $validator = Mockery::mock(ValidatorInterface::class);
         } else {
-            $validator = \Mockery::mock(LegacyValidatorInterface::class);
+            $validator = Mockery::mock(LegacyValidatorInterface::class);
         }
         $violationList = new ConstraintViolationList([
             new ConstraintViolation('firstName message', '', [], '', 'firstName', '1'),
             new ConstraintViolation('lastName message', '', [], '', 'last_name', '2'),
         ]);
         $validator->shouldReceive('validate')->andReturn($violationList);
-        $propertyPathConverter = \Mockery::mock(PropertyPathConverterInterface::class);
+        $propertyPathConverter = Mockery::mock(PropertyPathConverterInterface::class);
         $propertyPathConverter->shouldReceive('convert')->andReturnUsing(function ($path) {
             return strtoupper($path);
         });
@@ -492,8 +493,8 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
         $this->apiManager->shouldReceive('isRestRequest')->andReturn(true);
         $this->apiManager->shouldReceive('getCacheStrategy');
 
-        $httpKernelMock = \Mockery::mock(HttpKernelInterface::class);
-        $requestMock = \Mockery::mock(Request::class);
+        $httpKernelMock = Mockery::mock(HttpKernelInterface::class);
+        $requestMock = Mockery::mock(Request::class);
 
         $event = new GetResponseForControllerResultEvent(
             $httpKernelMock,
@@ -530,12 +531,13 @@ class RestListenerTest extends \PHPUnit_Framework_TestCase
             $this->logger,
             $this->parameterToEntityMapBuilder,
             $this->requestLogger,
-            $this->exceptionLogger
+            $this->exceptionLogger,
+            []
         );
     }
 
     private function createPropertiesAwareValidator()
     {
-        return \Mockery::mock(PropertiesAwareValidator::class);
+        return Mockery::mock(PropertiesAwareValidator::class);
     }
 }


### PR DESCRIPTION
- New optional bundle configuration parameter `locales`;
- `\Symfony\Component\HttpFoundation\Request::getLocale` now can return preferred locale from the `Accept-Language` header, which resolves from the `locales` parameter in the bundle configuration;
- Fixed some of the test styles;